### PR TITLE
Fix typo in the "getWebhookInfo" method name

### DIFF
--- a/src/telegrambot_lib/core.clj
+++ b/src/telegrambot_lib/core.clj
@@ -142,4 +142,4 @@
   get-updates
   set-webhook
   delete-webhook
-  get-webhook])
+  get-webhook-info])

--- a/src/telegrambot_lib/updates/core.clj
+++ b/src/telegrambot_lib/updates/core.clj
@@ -81,7 +81,7 @@
   ([this content]
    (http/request this "deleteWebhook" content)))
 
-(defn get-webhook
+(defn get-webhook-info
   "Use this method to get current webhook status.
    On success, returns a WebhookInfo object.
    If the bot is using getUpdates, will return an object with the
@@ -90,11 +90,11 @@
    Required
    - this ; a bot instance"
   [this]
-  (http/request this "getWebhook"))
+  (http/request this "getWebhookInfo"))
 
 (def behavior
   "Map for extending the core TBot record with functions."
   {:get-updates get-updates
    :set-webhook set-webhook
    :delete-webhook delete-webhook
-   :get-webhook get-webhook})
+   :get-webhook-info get-webhook-info})

--- a/src/telegrambot_lib/updates/protocol.clj
+++ b/src/telegrambot_lib/updates/protocol.clj
@@ -23,7 +23,7 @@
      switch back to getUpdates.
      Returns True on success.")
 
-  (get-webhook [this]
+  (get-webhook-info [this]
     "Use this method to get current webhook status.
      On success, returns a WebhookInfo object.
      If the bot is using getUpdates, will return an object with the


### PR DESCRIPTION
Hi Bill!

Me again. =)

These is a typo in the `get-webhook` method name.
Sadly, it messes up both the name of the protocol fn _and_ the Bot API endpoint.

Cheers,
Mark