### PR TITLE
Add an ability to send requests asynchronously

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [com.taoensso/timbre "5.1.2"]
                  [environ "1.2.0"]
                  [org.clojure/clojure "1.10.3"]
+                 [org.clojure/core.async "1.3.618"]
                  [potemkin "0.4.5"]]
   :repl-options {:init-ns telegrambot-lib.core}
   :profiles {:dev [:project/dev :profiles/dev]


### PR DESCRIPTION
Hi Bill!

I'd like to send some requests to the Telegram Bot API asynchronously, so I decided to contribute this feature to your lib.
The implementation is idiomatic (it simply returns a one-off `core.async` channel) and non-invasive (suites your design well).
I've also manually tested it with my personal bot, and all synchronous Bot API requests continue to work as before.

Please, take a look at this PR. Hope you find this useful. Or maybe you decide to change the `request` contract a bit.

Cheers,
Mark