### PR TITLE
issue-105: Review/Implement Bot API 6.0 Changes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject telegrambot-lib "1.4.0"
+(defproject telegrambot-lib "1.5.0"
   :description "A library for interacting with the Telegram Bot API."
   :url "https://github.com/wdhowe/telegrambot-lib"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[clj-http "3.12.3"]
                  [environ "1.2.0"]
-                 [org.clojure/clojure "1.10.3"]
+                 [org.clojure/clojure "1.11.1"]
                  [org.clojure/core.async "1.5.648"]
                  [org.clojure/tools.logging "1.2.4"]
                  [potemkin "0.4.5"]]
@@ -15,7 +15,7 @@
              ;; only edit :profiles/* in profiles.clj
              :profiles/dev {}
              :profiles/test {}
-             :project/dev {:dependencies [[ch.qos.logback/logback-classic "1.2.10"]]
+             :project/dev {:dependencies [[ch.qos.logback/logback-classic "1.2.11"]]
                            :plugins [[lein-environ "1.1.0"]]
                            :source-paths ["env/dev/clj"]
                            :resource-paths ["env/dev/resources"]}

--- a/src/telegrambot_lib/core.clj
+++ b/src/telegrambot_lib/core.clj
@@ -44,7 +44,7 @@
 
 ;; Make all Telegram functions available directly in this namespace.
 (import-vars
- [telegrambot-lib.edit.core
+ [edit
   edit-message-text
   edit-message-text-inline
   edit-message-caption
@@ -55,15 +55,16 @@
   edit-message-reply-markup-inline
   stop-poll
   delete-message]
- [telegrambot-lib.games.core
+ [games
   send-game
   set-game-score
   set-game-score-inline
   get-game-high-scores
   get-game-high-scores-inline]
- [telegrambot-lib.inline.core
-  answer-inline-query]
- [telegrambot-lib.methods.core
+ [inline
+  answer-inline-query
+  answer-web-app-query]
+ [methods
   call
   get-me
   log-out
@@ -124,16 +125,20 @@
   answer-callback-query
   set-my-commands
   delete-my-commands
-  get-my-commands]
- [telegrambot-lib.passport.core
+  get-my-commands
+  set-chat-menu-button
+  get-chat-menu-button
+  set-my-default-administrator-rights
+  get-my-default-administrator-rights]
+ [passport
   set-passport-data-errors]
- [telegrambot-lib.payments.core
+ [payments
   send-invoice
   answer-shipping-query-ok
   answer-shipping-query-error
   answer-precheckout-query-ok
   answer-precheckout-query-error]
- [telegrambot-lib.stickers.core
+ [stickers
   send-sticker
   get-sticker-set
   upload-sticker-file
@@ -142,7 +147,7 @@
   set-sticker-position-in-set
   delete-sticker-from-set
   set-sticker-set-thumb]
- [telegrambot-lib.updates.core
+ [updates
   get-updates
   set-webhook
   delete-webhook

--- a/src/telegrambot_lib/inline/core.clj
+++ b/src/telegrambot_lib/inline/core.clj
@@ -39,6 +39,26 @@
                          :results results})]
      (answer-inline-query this content))))
 
+(defn answer-web-app-query
+  "Use this method to set the result of an interaction with a Web App and
+   send a corresponding message on behalf of the user to the chat from
+   which the query originated.
+   On success, a SentWebAppMessage object is returned.
+
+   Required
+   - this ; a bot instance
+   - web_app_query_id ; id for the answered query
+   - result ; json object describing message to be sent"
+  {:added "1.5.0"}
+  ([this content]
+   (http/request this "answerWebAppQuery" content))
+
+  ([this web_app_query_id result]
+   (let [content {:web_app_query_id web_app_query_id
+                  :result result}]
+     (answer-inline-query this content))))
+
 (def behavior
   "Map for extending the core TBot record with functions."
-  {:answer-inline-query answer-inline-query})
+  {:answer-inline-query answer-inline-query
+   :answer-web-app-query answer-web-app-query})

--- a/src/telegrambot_lib/inline/protocol.clj
+++ b/src/telegrambot_lib/inline/protocol.clj
@@ -9,4 +9,11 @@
     [this inline_query_id results]
     [this inline_query_id results & optional]
     "Use this method to send answers to an inline query. On success, True is returned.
-     No more than 50 results per query are allowed."))
+     No more than 50 results per query are allowed.")
+
+  (answer-web-app-query [this content]
+    [this web_app_query_id result]
+    "Use this method to set the result of an interaction with a Web App and
+     send a corresponding message on behalf of the user to the chat from
+     which the query originated.
+     On success, a SentWebAppMessage object is returned."))

--- a/src/telegrambot_lib/methods/core.clj
+++ b/src/telegrambot_lib/methods/core.clj
@@ -974,7 +974,7 @@
    - can_delete_messages ; true if admin can delete messages of other users
    - can_invite_users ; true if admin can invite new users to chat
    - can_restrict_members ; true if admin can restrict, ban, unban members
-   - can_manage_voice_chats ; true if admin can manage voice chats, supergroups only
+   - can_manage_video_chats ; true if admin can manage video chats, supergroups only
    - can_pin_messages ; true if admin can pin messages
    - can_promote_members ; true if admin can add new admins"
   ([this content]
@@ -1611,6 +1611,80 @@
   ([this content]
    (http/request this "getMyCommands" content)))
 
+(defn set-chat-menu-button
+  "Use this method to change the bot's menu button in a private chat, or the default menu button.
+   Returns True on success.
+
+   Required
+   - this ; a bot instance
+
+   Optional
+   - chat_id ; target chat or username (@user)
+   - menu_button ; A JSON-serialized object for the new bot's menu button. Defaults to MenuButtonDefault."
+  {:added "1.5.0"}
+  ([this]
+   (http/request this "setChatMenuButton"))
+
+  ([this content]
+   (http/request this "setChatMenuButton" content)))
+
+(defn get-chat-menu-button
+  "Use this method to get the current value of the bot's menu button in a private chat, or the
+   default menu button.
+   Returns MenuButton on success.
+
+   Required
+   - this ; a bot instance
+
+   Optional
+   - chat_id ; target chat or username (@user)"
+  {:added "1.5.0"}
+  ([this]
+   (http/request this "getChatMenuButton"))
+
+  ([this content]
+   (http/request this "getChatMenuButton" content)))
+
+(defn set-my-default-administrator-rights
+  "Use this method to change the default administrator rights requested by the bot when it's added
+   as an administrator to groups or channels.
+   These rights will be suggested to users, but they are are free to modify the list before adding the bot.
+   Returns True on success.
+
+   Required
+   - this ; a bot instance
+
+   Optional
+   - rights ; A JSON-serialized object describing new default administrator rights.
+              If not specified, the default administrator rights will be cleared.
+   - for_channels ; Pass True to change the default administrator rights of the bot in channels.
+                    Otherwise, the default administrator rights of the bot for groups and
+                    supergroups will be changed."
+  {:added "1.5.0"}
+  ([this]
+   (http/request this "setMyDefaultAdministratorRights"))
+
+  ([this content]
+   (http/request this "setMyDefaultAdministratorRights" content)))
+
+(defn get-my-default-administrator-rights
+  "Use this method to get the current default administrator rights of the bot.
+   Returns ChatAdministratorRights on success.
+
+   Required
+   - this ; a bot instance
+
+   Optional
+   - for_channels ; Pass True to get default administrator rights of the bot in channels.
+                    Otherwise, default administrator rights of the bot for groups and
+                    supergroups will be returned."
+  {:added "1.5.0"}
+  ([this]
+   (http/request this "getMyDefaultAdministratorRights"))
+
+  ([this content]
+   (http/request this "getMyDefaultAdministratorRights" content)))
+
 (def behavior
   "Map for extending the core TBot record with functions."
   {:call call
@@ -1673,4 +1747,8 @@
    :answer-callback-query answer-callback-query
    :set-my-commands set-my-commands
    :delete-my-commands delete-my-commands
-   :get-my-commands get-my-commands})
+   :get-my-commands get-my-commands
+   :set-chat-menu-button set-chat-menu-button
+   :get-chat-menu-button get-chat-menu-button
+   :set-my-default-administrator-rights set-my-default-administrator-rights
+   :get-my-default-administrator-rights get-my-default-administrator-rights})

--- a/src/telegrambot_lib/methods/protocol.clj
+++ b/src/telegrambot_lib/methods/protocol.clj
@@ -421,4 +421,27 @@
   (get-my-commands [this]
     [this content]
     "Use this method to get the current list of the bot's commands.
-     Returns Array of BotCommand on success."))
+     Returns Array of BotCommand on success.")
+
+  (set-chat-menu-button [this]
+    [this content]
+    "Use this method to change the bot's menu button in a private chat, or the default menu button.
+     Returns True on success.")
+
+  (get-chat-menu-button [this]
+    [this content]
+    "Use this method to get the current value of the bot's menu button in a private chat, or the
+     default menu button.
+     Returns MenuButton on success.")
+
+  (set-my-default-administrator-rights [this]
+    [this content]
+    "Use this method to change the default administrator rights requested by the bot when it's added
+     as an administrator to groups or channels.
+     These rights will be suggested to users, but they are are free to modify the list before adding the bot.
+     Returns True on success.")
+
+  (get-my-default-administrator-rights [this]
+    [this content]
+    "Use this method to get the current default administrator rights of the bot.
+     Returns ChatAdministratorRights on success."))


### PR DESCRIPTION
- Dependency version bumps.
- New method, [answerWebAppQuery](https://core.telegram.org/bots/api#answerwebappquery)
- New method, [setChatMenuButton](https://core.telegram.org/bots/api#setchatmenubutton)
- New method, [getChatMenuButton](https://core.telegram.org/bots/api#getchatmenubutton)
- New method, [setMyDefaultAdministratorRights](https://core.telegram.org/bots/api#setmydefaultadministratorrights)
- New method, [getMyDefaultAdministratorRights](https://core.telegram.org/bots/api#getmydefaultadministratorrights)
- Parameter renamed, can_manage_voice_chats to can_manage_video_chats, in the method [promoteChatMember](https://core.telegram.org/bots/api#promotechatmember)

Closes #105 