### PR TITLE
http-tests: Add http request tests.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,8 @@
              ;; only edit :profiles/* in profiles.clj
              :profiles/dev {}
              :profiles/test {}
-             :project/dev {:dependencies [[ch.qos.logback/logback-classic "1.2.11"]]
+             :project/dev {:dependencies [[ch.qos.logback/logback-classic "1.2.11"]
+                                          [clj-http-fake "1.0.3"]]
                            :plugins [[lein-environ "1.1.0"]]
                            :source-paths ["env/dev/clj"]
                            :resource-paths ["env/dev/resources"]}

--- a/src/telegrambot_lib/http.clj
+++ b/src/telegrambot_lib/http.clj
@@ -39,7 +39,7 @@
 (defn gen-url
   "Generate the url to use for the http call, given the method `path`."
   [this path]
-  (str bot-api (:bot-token this) "/" path))
+  (format "%s%s/%s" bot-api (:bot-token this) path))
 
 (defn parse-resp
   "Parse the JSON response body into a keywordized map."

--- a/test/telegrambot_lib/http_test.clj
+++ b/test/telegrambot_lib/http_test.clj
@@ -1,5 +1,6 @@
 (ns telegrambot-lib.http-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clj-http.fake :as fake]
             [telegrambot-lib.http :as http]))
 
 (deftest gen-url-test
@@ -7,7 +8,79 @@
     (is (= "https://api.telegram.org/bot1234/myTest"
            (http/gen-url {:bot-token "1234"} "myTest")))))
 
-;; todo - test for a good url response with clj-http-fake
-;;        (for showing this project's expected http return data structures)
+(def ok-resp
+  {:cached nil
+   :request-time 545
+   :repeatable? false
+   :protocol-version {:name "HTTP", :major 1, :minor 1}
+   :streaming? true
+   :chunked? false
+   :reason-phrase "OK"
+   :headers
+   {"Access-Control-Expose-Headers" "Content-Length,Content-Type,Date,Server,Connection"
+    "Server" "nginx/1.18.0"
+    "Content-Type" "application/json"
+    "Access-Control-Allow-Origin" "*"
+    "Content-Length" "196"
+    "Strict-Transport-Security" "max-age=31536000; includeSubDomains; preload"
+    "Connection" "close"
+    "Access-Control-Allow-Methods" "GET, POST, OPTIONS"
+    "Date" "Sat, 23 Jul 2022 22:37:36 GMT"}
+   :orig-content-encoding nil
+   :status 200
+   :length 196
+   :body
+   "{\"ok\":true,\"result\":{\"id\":123,\"is_bot\":true,\"first_name\":\"mybot\",\"username\":\"my_roboto\",\"can_join_groups\":true,\"can_read_all_group_messages\":true,\"supports_inline_queries\":false}}"
+   :trace-redirects []})
 
-;; todo - test for a bad url response with clj-http-fake
+(deftest request-ok-test
+  (testing "HTTP request to a valid endpoint with an ok response."
+    (fake/with-fake-routes {"https://api.telegram.org/bot1234/getMe"
+                            (fn [request] ok-resp)}
+      (let [resp (http/request {:bot-token "1234"} "getMe")]
+
+        (is (= resp {:ok true,
+                     :result
+                     {:id 123,
+                      :is_bot true,
+                      :first_name "mybot",
+                      :username "my_roboto",
+                      :can_join_groups true,
+                      :can_read_all_group_messages true,
+                      :supports_inline_queries false}}))))))
+
+(def not-found-resp
+  {:cached nil
+   :request-time 545
+   :repeatable? false
+   :protocol-version {:name "HTTP", :major 1, :minor 1}
+   :streaming? true
+   :chunked? false
+   :reason-phrase "Not Found"
+   :headers
+   {"Access-Control-Expose-Headers" "Content-Length,Content-Type,Date,Server,Connection"
+    "Server" "nginx/1.18.0"
+    "Content-Type" "application/json"
+    "Access-Control-Allow-Origin" "*"
+    "Content-Length" "196"
+    "Strict-Transport-Security" "max-age=31536000; includeSubDomains; preload"
+    "Connection" "close"
+    "Access-Control-Allow-Methods" "GET, POST, OPTIONS"
+    "Date" "Sat, 23 Jul 2022 22:37:36 GMT"}
+   :orig-content-encoding nil
+   :status 404
+   :length 55
+   :body
+   "{\"ok\":false,\"error_code\":404,\"description\":\"Not Found\"}"
+   :trace-redirects []})
+
+(deftest request-not-found-test
+  (testing "HTTP request to an invalid endpoint."
+    (fake/with-fake-routes {"https://api.telegram.org/bot1234/doesNotExist"
+                            (fn [request] not-found-resp)}
+      (let [resp (http/request {:bot-token "1234"} "doesNotExist")]
+
+        (is (= (:ok resp) false))
+        (is (= (:error_code resp) 404))
+        (is (= (:description resp) "Not Found"))
+        (is (:error resp))))))


### PR DESCRIPTION
- Added http/request tests in order to show the expected data structures
  when handling a 200 and 404 response.
- clj-http-fake added to the dev profile to support the new tests.