### PR TITLE
issue-128: Cannot create a webhook using custom certificate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>telegrambot-lib</groupId>
   <artifactId>telegrambot-lib</artifactId>
   <packaging>jar</packaging>
-  <version>2.7.0</version>
+  <version>2.8.0</version>
   <name>telegrambot-lib</name>
   <description>A library for interacting with the Telegram Bot API.</description>
   <url>https://github.com/wdhowe/telegrambot-lib</url>
@@ -18,7 +18,7 @@
     <url>https://github.com/wdhowe/telegrambot-lib</url>
     <connection>scm:git:git://github.com/wdhowe/telegrambot-lib.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/wdhowe/telegrambot-lib.git</developerConnection>
-    <tag>ef74dc91bf0c39285d87e1c7539872d2fd725916</tag>
+    <tag>d2b7d1960804a6e69c1d90a0f740ab7ef9e74881</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject telegrambot-lib "2.7.0"
+(defproject telegrambot-lib "2.8.0"
   :description "A library for interacting with the Telegram Bot API."
   :url "https://github.com/wdhowe/telegrambot-lib"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/test/telegrambot_lib/http_test.clj
+++ b/test/telegrambot_lib/http_test.clj
@@ -8,6 +8,16 @@
     (is (= "https://api.telegram.org/bot1234/myTest"
            (http/gen-url {:bot-token "1234"} "myTest")))))
 
+(deftest map->multipart-test
+  (testing "Request content map transformation test."
+    (is (= (http/map->multipart {:url "https://mybotwebhook.me"
+                                 :certificate "/home/bot/certs/mybot.pem"})
+           {:multipart
+            [{:name "url", :content "https://mybotwebhook.me"}
+             {:name "certificate", :content "/home/bot/certs/mybot.pem"}]}))
+    (is (= (http/map->multipart nil)
+           nil))))
+
 (def ok-resp
   {:cached nil
    :request-time 545


### PR DESCRIPTION
- New fn http/map->multipart that transforms a request content map into a multipart request map.
- Use multipart requests for all api post requests instead of only using it for requests with file uploads.

Closes #128 