### PR TITLE
issue-137: Attribute maps for fns that don't have them

### DIFF
--- a/src/telegrambot_lib/api/edit.clj
+++ b/src/telegrambot_lib/api/edit.clj
@@ -25,6 +25,8 @@
    - entities ; list of MessageEntity - can use instead of parse_mode
    - disable_web_page_preview ; disable link previews
    - reply_markup ; inline keyboard markup"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "editMessageText" content))
 
@@ -55,6 +57,8 @@
    - parse_mode ; entity parsing in message
    - disable_web_page_preview ; disable link previews
    - reply_markup ; inline keyboard markup"
+  {:added "0.2.0"}
+
   ([this content]
    (http/request this "editMessageText" content))
 
@@ -84,6 +88,8 @@
    - parse_mode ; entity parsing in message
    - caption_entities ; list of MessageEntity - can use instead of parse_mode
    - reply_markup ; inline keyboard markup"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "editMessageCaption" content))
 
@@ -113,6 +119,8 @@
    Optional
    - parse_mode ; entity parsing in message
    - reply_markup ; inline keyboard markup"
+  {:added "0.2.0"}
+
   ([this content]
    (http/request this "editMessageCaption" content))
 
@@ -144,6 +152,8 @@
 
    Optional
    - reply_markup ; inline keyboard markup"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "editMessageMedia" content))
 
@@ -176,6 +186,8 @@
 
    Optional
    - reply_markup ; inline keyboard markup"
+  {:added "0.2.0"}
+
   ([this content]
    (http/request this "editMessageMedia" content))
 
@@ -200,6 +212,8 @@
    - chat_id ; target chat or username (@user)
    - message_id ; id of message to edit
    - reply_markup ; inline keyboard markup"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "editMessageReplyMarkup" content))
 
@@ -218,6 +232,8 @@
    - this ; a bot instance
    - inline_message_id ; id of the inline message
    - reply_markup ; inline keyboard markup"
+  {:added "0.2.0"}
+
   ([this content]
    (http/request this "editMessageReplyMarkup" content))
 
@@ -237,6 +253,8 @@
 
    Optional
    - reply_markup ; inline keyboard markup"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "stopPoll" content))
 
@@ -259,6 +277,8 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - message_id ; id of message to delete"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "deleteMessage" content))
 

--- a/src/telegrambot_lib/api/games.clj
+++ b/src/telegrambot_lib/api/games.clj
@@ -25,6 +25,8 @@
    - reply_to_message_id ; id of original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; inline keyboard markup"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendGame" content))
 
@@ -55,6 +57,8 @@
    Optional
    - force ; true if high score is allowed to decrease
    - disable_edit_message ; true if game msg should not be auto edited to include the scoreboard"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "setGameScore" content))
 
@@ -88,6 +92,8 @@
    Optional
    - force ; true if high score is allowed to decrease
    - disable_edit_message ; true if game msg should not be auto edited to include the scoreboard"
+  {:added "0.2.0"}
+
   ([this content]
    (http/request this "setGameScore" content))
 
@@ -114,6 +120,8 @@
    - chat_id ; id of the target chat
    - message_id ; id of the sent message
    - user_id ; target user"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "getGameHighScores" content))
 
@@ -132,6 +140,8 @@
    - this ; a bot instance
    - inline_message_id ; id of the sent message
    - user_id ; target user"
+  {:added "0.2.0"}
+
   ([this content]
    (http/request this "getGameHighScores" content))
 

--- a/src/telegrambot_lib/api/inline.clj
+++ b/src/telegrambot_lib/api/inline.clj
@@ -25,6 +25,7 @@
    - next_offset ; Pagination offset a client should use for more results
    - button ; A JSON-serialized object describing a button to be shown above inline query results."
   {:changed "2.7.0"}
+
   ([this content]
    (http/request this "answerInlineQuery" content))
 
@@ -50,6 +51,7 @@
    - web_app_query_id ; id for the answered query
    - result ; json object describing message to be sent"
   {:added "1.5.0"}
+
   ([this content]
    (http/request this "answerWebAppQuery" content))
 

--- a/src/telegrambot_lib/api/methods.clj
+++ b/src/telegrambot_lib/api/methods.clj
@@ -21,6 +21,8 @@
 
    Optional
    - content ; parameters for the api method"
+  {:added "0.1.0"}
+
   ([this endpoint]
    (call this endpoint nil))
 
@@ -33,6 +35,7 @@
 
    Required
    - this ; a bot instance"
+  {:added "0.1.0"}
   [this]
   (http/request this "getMe"))
 
@@ -44,6 +47,7 @@
 
    Required
    - this ; a bot instance"
+  {:added "0.3.0"}
   [this]
   (http/request this "logOut"))
 
@@ -56,6 +60,7 @@
 
    Required
    - this ; a bot instance"
+  {:added "0.3.0"}
   [this]
   (http/request this "close"))
 
@@ -78,6 +83,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendMessage" content))
 
@@ -106,6 +113,8 @@
    - message_thread_id ; id of the target thread of the forum.
    - disable_notification ; send silently
    - protect_content ; protect content from forwarding/saving"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "forwardMessage" content))
 
@@ -144,6 +153,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:added "0.3.0"}
+
   ([this content]
    (http/request this "copyMessage" content))
 
@@ -180,6 +191,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendPhoto" content))
 
@@ -219,6 +232,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendAudio" content))
 
@@ -254,6 +269,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendDocument" content))
 
@@ -294,6 +311,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendVideo" content))
 
@@ -333,6 +352,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendAnimation" content))
 
@@ -370,6 +391,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendVoice" content))
 
@@ -403,6 +426,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendVideoNote" content))
 
@@ -432,6 +457,8 @@
    - protect_content ; protect content from forwarding/saving
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendMediaGroup" content))
 
@@ -467,6 +494,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendLocation" content))
 
@@ -502,6 +531,8 @@
    - heading ; 1-360 degrees direction user is moving
    - proximity_alert_radius ; 1-100000 meters max distance for proximity alerts
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "editMessageLiveLocation" content))
 
@@ -535,6 +566,8 @@
 
    Optional
    - reply_markup ; additional interface options"
+  {:added "0.2.0"}
+
   ([this content]
    (http/request this "editMessageLiveLocation" content))
 
@@ -563,6 +596,8 @@
 
    Optional
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "stopMessageLiveLocation" content))
 
@@ -589,6 +624,7 @@
 
    Optional
    - reply_markup ; additional interface options"
+  {:added "0.2.0"}
   content-map?)
 
 (defmethod stop-message-live-location-inline true
@@ -628,6 +664,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendVenue" content))
 
@@ -667,6 +705,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendContact" content))
 
@@ -718,6 +758,8 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendPoll" content))
 
@@ -750,6 +792,7 @@
    - reply_to_message_id ; id of the original message
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod send-dice true
@@ -781,6 +824,8 @@
 
    Optional
    - message_thread_id ; unique id for target message thread."
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendChatAction" content))
 
@@ -806,6 +851,7 @@
    Optional
    - offset ; number of first photo returned
    - limit ; limit number of photos retrieved (1-100, default: 100)"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod get-user-profile-photos true
@@ -834,6 +880,7 @@
    Required
    - this ; a bot instance
    - file_id ; file id to get info about"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod get-file true
@@ -865,6 +912,7 @@
                        always true for supergroups and channels."
   {:deprecated "0.3.4"
    :use-instead (symbol 'ban-chat-member)}
+
   ([this content]
    (http/request this "kickChatMember" content))
 
@@ -898,6 +946,7 @@
    - revoke_messages ; true to delete all messages from chat for user being removed.
                        always true for supergroups and channels."
   {:added "0.3.4"}
+
   ([this content]
    (http/request this "banChatMember" content))
 
@@ -925,6 +974,8 @@
 
    Optional
    - only_if_banned ; Do nothing if the user is not banned"
+  {:changed "0.3.0"}
+
   ([this content]
    (http/request this "unbanChatMember" content))
 
@@ -957,6 +1008,8 @@
                                         Otherwise, some permissions imply others.
    - until_date ; unix time when user is unbanned. 30 seconds - 366 days.
                   if less or more, user is banned forever."
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "restrictChatMember" content))
 
@@ -998,6 +1051,8 @@
    - can_pin_messages ; true if admin can pin messages
    - can_promote_members ; true if admin can add new admins
    - can_manage_topics ; true if user is allowed to create,rename,close,reopen forum topics."
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "promoteChatMember" content))
 
@@ -1022,6 +1077,8 @@
    - chat_id ; target chat or username (@user)
    - user_id ; id of target user
    - custom_title ; new custom title for the admin"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "setChatAdministratorCustomTitle" content))
 
@@ -1046,6 +1103,7 @@
    Optional
    - until_date ; date in unix time when the sender chat will be unbanned"
   {:added "1.2.0"}
+
   ([this content]
    (http/request this "banChatSenderChat" content))
 
@@ -1070,6 +1128,7 @@
    - chat_id ; target chat or username (@user)
    - sender_chat_id ; target sender chat"
   {:added "1.2.0"}
+
   ([this content]
    (http/request this "unbanChatSenderChat" content))
 
@@ -1092,6 +1151,8 @@
    Optional
    - use_independent_chat_permissions ; True if chat permissions are set independently.
                                         Otherwise, some permissions imply others."
+  {:changed "2.5.0"}
+
   ([this content]
    (http/request this "setChatPermissions" content))
 
@@ -1115,6 +1176,7 @@
    Required
    - this ; a bot instance
    - chat_id ; target chat or username (@user)"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod export-chat-invite-link true
@@ -1141,6 +1203,7 @@
    - expire_date ; unix timestamp when the link will expire
    - member_limit ; max num users that can be members simulatneously (1-99999)
    - creates_join_request ; true if users joining need to be approved"
+  {:added "0.3.2"}
   content-map?)
 
 (defmethod create-chat-invite-link true
@@ -1172,6 +1235,8 @@
    - expire_date ; unix timestamp when the link will expire
    - member_limit ; max num users that can be members simulatneously (1-99999)
    - creates_join_request ; true if users joining need to be approved"
+  {:added "0.3.2"}
+
   ([this content]
    (http/request this "editChatInviteLink" content))
 
@@ -1196,6 +1261,8 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - invite_link ; invite link to revoke"
+  {:added "0.3.2"}
+
   ([this content]
    (http/request this "revokeChatInviteLink" content))
 
@@ -1214,6 +1281,8 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - user_id ; id of target user"
+  {:added "1.1.0"}
+
   ([this content]
    (http/request this "approveChatJoinRequest" content))
 
@@ -1232,6 +1301,8 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - user_id ; id of target user"
+  {:added "1.1.0"}
+
   ([this content]
    (http/request this "declineChatJoinRequest" content))
 
@@ -1251,6 +1322,8 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - photo ; new chat photo"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "setChatPhoto" content))
 
@@ -1268,6 +1341,7 @@
    Required
    - this ; a bot instance
    - chat_id ; target chat or username (@user)"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod delete-chat-photo true
@@ -1290,6 +1364,8 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - title ; new chat title"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "setChatTitle" content))
 
@@ -1308,6 +1384,8 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - description ; new chat description"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "setChatDescription" content))
 
@@ -1330,6 +1408,8 @@
 
    Optional
    - disable_notification ; true to pin silently. default true in channels."
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "pinChatMessage" content))
 
@@ -1357,6 +1437,7 @@
 
    Optional
    - message_id ; id of message to unpin (unpins most recent if not specified)"
+  {:changed "0.3.0"}
   content-map?)
 
 (defmethod unpin-chat-message true
@@ -1383,6 +1464,7 @@
    Required
    - this ; a bot instance
    - chat_id ; target chat or username (@user)"
+  {:added "0.3.0"}
   content-map?)
 
 (defmethod unpin-all-chat-messages true
@@ -1401,6 +1483,7 @@
    Required
    - this ; a bot instance
    - chat_id ; target chat or username (@user)"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod leave-chat true
@@ -1421,6 +1504,7 @@
    Required
    - this ; a bot instance
    - chat_id ; target chat or username (@user)"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod get-chat true
@@ -1442,6 +1526,7 @@
    Required
    - this ; a bot instance
    - chat_id ; target chat or username (@user)"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod get-chat-administrators true
@@ -1500,6 +1585,8 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - user_id ; id of target user"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "getChatMember" content))
 
@@ -1520,6 +1607,8 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - sticker_set_name ; name of sticker set"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "setChatStickerSet" content))
 
@@ -1539,6 +1628,7 @@
    Required
    - this ; a bot instance
    - chat_id ; target chat or username (@user)"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod delete-chat-sticker-set true
@@ -1557,6 +1647,7 @@
 
    Required
    - this ; a bot instance"
+  {:added "2.3.0"}
   [this]
   (http/request this "getForumTopicIconStickers"))
 
@@ -1574,6 +1665,7 @@
    Optional
    - icon_color ; integer color of the topic icon in RGB format.
    - icon_custom_emoji_id ; string id of custom emoji shown as topic icon."
+  {:added "2.3.0"}
 
   ([this content]
    (http/request this "createForumTopic" content))
@@ -1629,6 +1721,7 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - message_thread_id ; id of the target thread of the forum."
+  {:added "2.3.0"}
 
   ([this content]
    (http/request this "closeForumTopic" content))
@@ -1648,6 +1741,7 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - message_thread_id ; id of the target thread of the forum."
+  {:added "2.3.0"}
 
   ([this content]
    (http/request this "reopenForumTopic" content))
@@ -1667,6 +1761,7 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - message_thread_id ; id of the target thread of the forum."
+  {:added "2.3.0"}
 
   ([this content]
    (http/request this "deleteForumTopic" content))
@@ -1686,6 +1781,7 @@
    - this ; a bot instance
    - chat_id ; target chat or username (@user)
    - message_thread_id ; id of the target thread of the forum."
+  {:added "2.3.0"}
 
   ([this content]
    (http/request this "unpinAllForumTopicMessages" content))
@@ -1835,6 +1931,7 @@
    - show_alert ; if true, show alert instead of a notification
    - url ; url that will be opened by the user's client.
    - cache_time ; max time in seconds for caching callback query. (default: 0)"
+  {:changed "0.3.5"}
   content-map?)
 
 (defmethod answer-callback-query true
@@ -1862,6 +1959,7 @@
    Optional
    - scope ; JSON object, scope of users that commands are relevant for. (default: BotCommandScopeDefault)
    - language_code ; Two-letter ISO 639-1 lang code. If empty, commands applied to all users from given scope."
+  {:changed "0.3.4"}
   content-map?)
 
 (defmethod set-my-commands true
@@ -1890,6 +1988,7 @@
    - scope ; JSON object, scope of users that commands are relevant for. (default: BotCommandScopeDefault)
    - language_code ; Two-letter ISO 639-1 lang code. If empty, commands applied to all users from given scope."
   {:added "0.3.4"}
+
   ([this]
    (http/request this "deleteMyCommands"))
 
@@ -1906,6 +2005,8 @@
    Optional
    - scope ; JSON object, scope of users that commands are relevant for. (default: BotCommandScopeDefault)
    - language_code ; Two-letter ISO 639-1 lang code. If empty, commands applied to all users from given scope."
+  {:changed "0.3.4"}
+
   ([this]
    (http/request this "getMyCommands"))
 
@@ -1923,6 +2024,7 @@
    - name ; New bot name. Pass an empty string to remove the name.
    - language_code ; Two-letter ISO 639-1 lang code. If empty, name applied to all users."
   {:added "2.7.0"}
+
   ([this]
    (http/request this "setMyName"))
 
@@ -1939,6 +2041,7 @@
    Optional
    - language_code ; Two-letter ISO 639-1 lang code."
   {:added "2.7.0"}
+
   ([this]
    (http/request this "getMyName"))
 
@@ -1957,6 +2060,7 @@
    - description ; New bot description. Pass empty string to remove description.
    - language_code ; Two-letter ISO 639-1 lang code. If empty, description applied to all users."
   {:added "2.6.0"}
+
   ([this]
    (http/request this "setMyDescription"))
 
@@ -1973,6 +2077,7 @@
    Optional
    - language_code ; Two-letter ISO 639-1 lang code or an empty string."
   {:added "2.6.0"}
+
   ([this]
    (http/request this "getMyDescription"))
 
@@ -1992,6 +2097,7 @@
    - short_description ; New bot short description. Pass empty string to remove description.
    - language_code ; Two-letter ISO 639-1 lang code. If empty, description applied to all users."
   {:added "2.6.0"}
+
   ([this]
    (http/request this "setMyShortDescription"))
 
@@ -2008,6 +2114,7 @@
    Optional
    - language_code ; Two-letter ISO 639-1 lang code or an empty string."
   {:added "2.6.0"}
+
   ([this]
    (http/request this "getMyShortDescription"))
 
@@ -2025,6 +2132,7 @@
    - chat_id ; target chat or username (@user)
    - menu_button ; A JSON-serialized object for the new bot's menu button. Defaults to MenuButtonDefault."
   {:added "1.5.0"}
+
   ([this]
    (http/request this "setChatMenuButton"))
 
@@ -2042,6 +2150,7 @@
    Optional
    - chat_id ; target chat or username (@user)"
   {:added "1.5.0"}
+
   ([this]
    (http/request this "getChatMenuButton"))
 
@@ -2064,6 +2173,7 @@
                     Otherwise, the default administrator rights of the bot for groups and
                     supergroups will be changed."
   {:added "1.5.0"}
+
   ([this]
    (http/request this "setMyDefaultAdministratorRights"))
 
@@ -2082,6 +2192,7 @@
                     Otherwise, default administrator rights of the bot for groups and
                     supergroups will be returned."
   {:added "1.5.0"}
+
   ([this]
    (http/request this "getMyDefaultAdministratorRights"))
 

--- a/src/telegrambot_lib/api/passport.clj
+++ b/src/telegrambot_lib/api/passport.clj
@@ -16,6 +16,8 @@
    - this ; a bot instance
    - user_id ; user identifier
    - errors ; json array of 'PassportElementError' describing the errors"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "setPassportDataErrors" content))
 

--- a/src/telegrambot_lib/api/payments.clj
+++ b/src/telegrambot_lib/api/payments.clj
@@ -47,6 +47,8 @@
    - reply_to_message_id ; id of original message if a reply
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; inline keyboard markup"
+  {:changed "0.3.3"}
+
   ([this content]
    (http/request this "sendInvoice" content))
 
@@ -101,6 +103,8 @@
    - send_phone_number_to_provider ; true to send phone number to provider
    - send_email_to_provider ; true to send email to provider
    - is_flexible ; true if final price depends on shipping method"
+  {:added "2.1.0"}
+
   ([this content]
    (http/request this "createInvoiceLink" content))
 
@@ -136,6 +140,8 @@
    - shipping_query_id ; id of query to be answered
    - ok ; true if delivery to address is possible (auto set by this function)
    - shipping_options ; Required if 'ok' is true, array of shipping options"
+  {:added "0.2.0"}
+
   ([this content]
    (http/request this "answerShippingQuery" content))
 
@@ -158,6 +164,8 @@
    - shipping_query_id ; id of query to be answered
    - ok ; true if delivery to address is possible (auto set by this function)
    - error_message ; Required if 'ok' is false, message why order cannot complete"
+  {:added "0.2.0"}
+
   ([this content]
    (http/request this "answerShippingQuery" content))
 
@@ -180,6 +188,7 @@
    - pre_checkout_query_id ; id of query to be answered
    - ok ; true if all is good (in stock, etc) and bot is ready to proceed with order
           (auto set by this function)"
+  {:added "0.2.0"}
   content-map?)
 
 (defmethod answer-precheckout-query-ok true
@@ -206,6 +215,8 @@
    - ok ; true if all is good (in stock, etc) and bot is ready to proceed with order
           (auto set by this function)
    - error_message ; Required if 'ok' is false, message why checkout cannot proceed"
+  {:added "0.2.0"}
+
   ([this content]
    (http/request this "answerPreCheckoutQuery" content))
 

--- a/src/telegrambot_lib/api/stickers.clj
+++ b/src/telegrambot_lib/api/stickers.clj
@@ -27,6 +27,8 @@
    - reply_to_message_id ; id of original message if reply
    - allow_sending_without_reply ; true to send message even if replied-to message is not found
    - reply_markup ; additional interface options"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "sendSticker" content))
 
@@ -48,6 +50,7 @@
    Required
    - this ; a bot instance
    - name ; name of the sticker set"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod get-sticker-set true
@@ -66,6 +69,7 @@
    Required
    - this ; a bot instance
    - custom_emoji_ids ; a list of emoji identifiers"
+  {:added "2.2.0"}
   content-map?)
 
 (defmethod get-custom-emoji-stickers true
@@ -89,6 +93,7 @@
                See https://core.telegram.org/stickers for technical requirements.
    - sticker_format ; Format of sticker, 'static', 'animated', or 'video'."
   {:changed "2.6.0"}
+
   ([this content]
    (http/request this "uploadStickerFile" content))
 
@@ -115,6 +120,7 @@
    - sticker_type ; Type of stickers, 'regular' (default), 'mask', 'custom_emoji'.
    - needs_repainting ; True if stickers must be repainted to color of text in messages. (custom emoji sets only)"
   {:changed "2.6.0"}
+
   ([this content]
    (http/request this "createNewStickerSet" content))
 
@@ -149,6 +155,7 @@
    - name ; sticker set name
    - sticker ; A JSON-serialized object(InputSticker) with info about the added sticker."
   {:changed "2.6.0"}
+
   ([this content]
    (http/request this "addStickerToSet" content))
 
@@ -167,6 +174,8 @@
    - this ; a bot instance
    - sticker ; file id of the sticker
    - position ; new sticker position in the set"
+  {:changed "0.2.0"}
+
   ([this content]
    (http/request this "setStickerPositionInSet" content))
 
@@ -182,6 +191,7 @@
    Required
    - this ; a bot instance
    - sticker ; file id of the sticker"
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod delete-sticker-from-set true
@@ -203,6 +213,7 @@
    - sticker ; File id of the sticker.
    - emoji_list ; A JSON-serialized list of 1-20 emoji associated with the sticker."
   {:added "2.6.0"}
+
   ([this content]
    (http/request this "setStickerEmojiList" content))
 
@@ -277,6 +288,7 @@
    - name ; Sticker set name.
    - title ; Sticker set title."
   {:added "2.6.0"}
+
   ([this content]
    (http/request this "setStickerSetTitle" content))
 
@@ -300,6 +312,7 @@
                  More information: https://core.telegram.org/bots/api#sending-files"
   {:deprecated "2.6.0"
    :use-instead (symbol 'set-sticker-set-thumbnail)}
+
   ([this content]
    (http/request this "setStickerSetThumbnail" content))
 
@@ -328,6 +341,7 @@
    - thumbnail ; A .WEBP or .PNG image with the thumbnail, or .TGS animation, or WEBM video.
                  More information: https://core.telegram.org/bots/api#sending-files"
   {:added "2.6.0"}
+
   ([this content]
    (http/request this "setStickerSetThumbnail" content))
 

--- a/src/telegrambot_lib/api/updates.clj
+++ b/src/telegrambot_lib/api/updates.clj
@@ -22,8 +22,11 @@
    - limit ; num of updates to retrieve (1-100). default: 100
    - timeout ; timeout in seconds. default: 0 (short poll)
    - allowed_updates ; json array of update types bot will receive"
+  {:added "0.1.0"}
+
   ([this]
    (get-updates this nil))
+
   ([this content]
    (http/request this "getUpdates" content)))
 
@@ -47,6 +50,7 @@
    - drop_pending_updates ; Pass True to drop all pending updates
    - secret_token ; 1-256 chars. Sent in header (X-Telegram-Bot-Api-Secret-Token)
                     to ensure request comes from your webhook."
+  {:changed "0.2.0"}
   content-map?)
 
 (defmethod set-webhook true
@@ -73,6 +77,8 @@
 
    Optional
    - drop_pending_updates ; Pass True to drop all pending updates"
+  {:changed "0.3.0"}
+
   ([this]
    (delete-webhook this nil))
 
@@ -87,5 +93,6 @@
 
    Required
    - this ; a bot instance"
+  {:changed "0.3.5"}
   [this]
   (http/request this "getWebhookInfo"))

--- a/src/telegrambot_lib/config.clj
+++ b/src/telegrambot_lib/config.clj
@@ -5,6 +5,7 @@
 
 (defn cfg
   "The default configuration data structure for a bot."
+  {:added "2.9.0"}
   []
   {:bot-token (:bot-token environ/env)
    :async     false

--- a/src/telegrambot_lib/core.clj
+++ b/src/telegrambot_lib/core.clj
@@ -16,11 +16,11 @@
 (defmulti create
   "Create a new Telegram Bot data structure.
    - No parameters attempts to load the `bot-token` from the environment.
-     Example: (create)
+     - Example: `(create)`
    - 1 parameter will use the passed in `bot-token`.
-     Example: (create 12345)
+     - Example: `(create \"12345\")`
    - Alternatively, parameters can be passed as a map instead.
-     Example: (create {:bot-token 12345})
+     - Example: `(create {:bot-token \"12345\"})`
    
    Optional Parameters
    - bot-token ; The token id of your bot. (default: load from environment)
@@ -28,6 +28,7 @@
    - bot-api ; The Telegram Bot API URL. (default: official hosted API)
    
    Returns: A map data structure of a bot config."
+  {:changed "2.9.0"}
   (fn
     ([] false)
     ([m] (map? m))))
@@ -38,11 +39,10 @@
 
 (defmethod create false
   ([]
-   (conf/cfg))
+   (create {}))
   
   ([bot-token]
-   (merge (conf/cfg)
-          {:bot-token bot-token})))
+   (create {:bot-token bot-token})))
 
 ;; Make all API functions available directly in this namespace.
 (import-vars

--- a/src/telegrambot_lib/core.clj
+++ b/src/telegrambot_lib/core.clj
@@ -28,7 +28,7 @@
    - bot-api ; The Telegram Bot API URL. (default: official hosted API)
    
    Returns: A map data structure of a bot config."
-  {:changed "2.9.0"}
+  {:changed "2.10.0"}
   (fn
     ([] false)
     ([m] (map? m))))

--- a/src/telegrambot_lib/http.clj
+++ b/src/telegrambot_lib/http.clj
@@ -9,12 +9,14 @@
 
 (defn- upper-case-name
   "Transform the passed in value to an all upper cased name."
+  {:added "1.0.0"}
   [x]
   (string/upper-case (name x)))
 
 (defmulti client
   "Send HTTP requests to the URL. Methods supported:
    - POST"
+  {:changed "2.8.0"}
   (fn [http-method & _] http-method))
 
 (defmethod client :post
@@ -35,11 +37,13 @@
 
 (defn gen-url
   "Generate the url to use for the http call, given the method `path`."
+  {:changed "2.9.0"}
   [this path]
   (format "%s%s/%s" (:bot-api this) (:bot-token this) path))
 
 (defn parse-resp
   "Parse the JSON response body into a keywordized map."
+  {:changed "1.0.0"}
   [resp]
   (try
     (-> resp :body json/parse-str)
@@ -48,6 +52,7 @@
 
 (defn ex->parsed-resp
   "Uniformly transform an `Exception` into a map to return."
+  {:added "1.0.0"}
   [ex]
   (let [body (parse-resp (ex-data ex))]
     ;; NB: This may overwrite the parsing exception, if any,
@@ -59,6 +64,7 @@
   "Transform a map's key/value pairs into a multipart map,
    with a list of maps with new keys.
    Eg: {:multipart [{:name key, :content value}] }"
+  {:added "2.8.0"}
   [m]
    (when (some? m)
      {:multipart (mapv #(assoc {} :name (name (first %)) :content (second %))
@@ -77,6 +83,7 @@
      request was unsuccessful (in terms of the Telegram Bot API), or
    - just an `{:error ex}` map in any other exceptional situation when we are
      unable to retrieve the response body."
+  {:changed "2.8.0"}
   (fn [this & _]
     (true? (:async this))))
 

--- a/src/telegrambot_lib/json.clj
+++ b/src/telegrambot_lib/json.clj
@@ -8,6 +8,7 @@
   "Returns the var to which a `var-name` will be resolved in the `ns` namespace
    (unless found in the environment), else `nil`. Also checks that the returned
    var dereferences to a function."
+  {:added "1.0.0"}
   [ns var-name]
   (let [resolved-var (ns-resolve ns (symbol var-name))]
     (if (and (some? resolved-var) (not (fn? @resolved-var)))
@@ -67,6 +68,7 @@
 (defn- build-json-str-parser
   "Builds a JSON string parser fn — the one that takes a JSON-encoded string
    and parses a Clojure object out of it."
+  {:added "1.0.0"}
   [lib]
   (let [parser-fn (resolve-fn-var (:core-lib-ns lib)
                                   (:parser-fn-name lib))]
@@ -79,12 +81,14 @@
 
 (defn parse-str
   "Parses (reads) a given JSON-encoded string into a Clojure object."
+  {:added "1.0.0"}
   [json-str]
   (json-str-parser json-str))
 
 (defn- build-json-str-generator
   "Builds a JSON string generator fn — the one that takes a Clojure object
    and generates its JSON-encoded string representation."
+  {:added "1.0.0"}
   [lib]
   (resolve-fn-var (:core-lib-ns lib)
                   (:generator-fn-name lib)))
@@ -96,5 +100,6 @@
 
 (defn generate-str
   "Generates (writes) a JSON-encoded string for a given Clojure object."
+  {:added "1.0.0"}
   [clj-obj]
   (json-str-generator clj-obj))

--- a/src/telegrambot_lib/predicates.clj
+++ b/src/telegrambot_lib/predicates.clj
@@ -4,5 +4,6 @@
 
 (defn content-map?
   "Used throughout the multi-methods in order to check if content is a map or not."
+  {:added "2.0.0"}
   [_ content & _]
   (map? content))


### PR DESCRIPTION
Functions that don't have attribute maps should have them added.

Changes made in direct support of this feature

- Attribute maps added to all functions that didn't have them.

Additional changes while working on this feature

- core/create's multi-arity calls simplified.

Closes #137 