### PR TITLE
issue-139: Multipart content cannot be nil

### DIFF
--- a/env/dev/fiddles/telegrambot_lib/core.clj
+++ b/env/dev/fiddles/telegrambot_lib/core.clj
@@ -38,7 +38,8 @@
 (println "\n---------- Call function: set-webhook ----------")
 (clojure.pprint/pprint
  (set-webhook bot {:url (:cert-url environ/env)
-                   :certificate (clojure.java.io/file (:cert-file environ/env))}))
+                   :certificate (clojure.java.io/file (:cert-file environ/env))
+                   :content-type :multipart}))
 
 (println "\n---------- Call function: get-webhook ----------")
 (clojure.pprint/pprint

--- a/env/dev/fiddles/telegrambot_lib/core.clj
+++ b/env/dev/fiddles/telegrambot_lib/core.clj
@@ -3,21 +3,47 @@
    This fiddle file was made to work with Calva, a vscode extension.
    It assumes a \"profiles.clj\" exists in the project root (git ignored) with:
    {:local {:env {:bot-token \"MY-BOT-TOKEN-HERE\"
-                  :chat-id \"MY-CHAT-ID-HERE\"}}}"
+                  :chat-id \"MY-CHAT-ID-HERE\"
+                  :cert-url \"MY-CERT-URL-HERE\"
+                  :cert-file \"/PATH/TO/CERT/FILE\"}}}"
   {:clj-kondo/config
    '{:linters {:unresolved-symbol {:level :off}}}}
   (:require [environ.core :as environ]
+            [clojure.java.io]
             [clojure.pprint]))
 
 ; Assumes bot-token is available from the environ or local profiles.clj.
-(println "Create bot")
+(println "---------- Create bot ----------")
 (def bot (create))
 
-(println "\nCall function: get-me")
+(println "\n---------- Call function: get-me ----------")
 (clojure.pprint/pprint (get-me bot))
 
 ; Assumes chat-id is available from the environ or local profiles.clj.
-(println "\nCall function: send-message")
+(println "\n---------- Call function: send-message ----------")
 (clojure.pprint/pprint
  (send-message bot (:chat-id environ/env)
                (format "Test message - %s." (str (java.time.LocalDateTime/now)))))
+
+(println "\n---------- Call function: get-updates (long check) ----------")
+(clojure.pprint/pprint
+ (get-updates bot {:timeout 10}))
+
+(println "\n---------- Call function: get-updates (nil check) ----------")
+(clojure.pprint/pprint
+ (get-updates bot {:offset nil
+                   :timeout 10}))
+
+; Assumes cert-url and cert-file are available from the environ or local profiles.clj.
+(println "\n---------- Call function: set-webhook ----------")
+(clojure.pprint/pprint
+ (set-webhook bot {:url (:cert-url environ/env)
+                   :certificate (clojure.java.io/file (:cert-file environ/env))}))
+
+(println "\n---------- Call function: get-webhook ----------")
+(clojure.pprint/pprint
+ (get-webhook-info bot))
+
+(println "\n---------- Call function: set-webhook nil ----------")
+(clojure.pprint/pprint
+ (set-webhook bot ""))

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>telegrambot-lib</groupId>
   <artifactId>telegrambot-lib</artifactId>
   <packaging>jar</packaging>
-  <version>2.9.0</version>
+  <version>2.10.0</version>
   <name>telegrambot-lib</name>
   <description>A library for interacting with the Telegram Bot API.</description>
   <url>https://github.com/wdhowe/telegrambot-lib</url>
@@ -18,7 +18,7 @@
     <url>https://github.com/wdhowe/telegrambot-lib</url>
     <connection>scm:git:git://github.com/wdhowe/telegrambot-lib.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/wdhowe/telegrambot-lib.git</developerConnection>
-    <tag>ae81e5bc1ba607e30153b3ba8e7470885400a741</tag>
+    <tag>1d906f8a2ec904d4ab6a4ea3b358077609b61674</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -95,6 +95,12 @@
       <groupId>potemkin</groupId>
       <artifactId>potemkin</artifactId>
       <version>0.4.6</version>
+    </dependency>
+    <dependency>
+      <groupId>clj-http-fake</groupId>
+      <artifactId>clj-http-fake</artifactId>
+      <version>1.0.4</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject telegrambot-lib "2.9.0"
+(defproject telegrambot-lib "2.10.0"
   
   ;;; Project Metadata
   :description "A library for interacting with the Telegram Bot API."
@@ -30,9 +30,9 @@
                     :resource-paths ["env/test/resources"]}
              
              ;; Select one of these json profiles during REPL jack-in.
-             :cheshire {:dependencies [[cheshire "5.11.0"]]}
+             :cheshire {:dependencies [[cheshire "5.12.0"]]}
              
-             :jsonista {:dependencies [[metosin/jsonista "0.3.7"]]}
+             :jsonista {:dependencies [[metosin/jsonista "0.3.8"]]}
              
              :data.json {:dependencies [[org.clojure/data.json "2.4.0"]]}}
   

--- a/test/telegrambot_lib/http_test.clj
+++ b/test/telegrambot_lib/http_test.clj
@@ -25,6 +25,24 @@
     (is (= (http/map->multipart nil)
            nil))))
 
+(deftest format-content-test
+  (testing "Format content as json and multipart."
+    ;; content-type not specified, use default json
+    (is (= (http/format-content {:url "http://my.url.com", :cert "mycert.pem"})
+           {:body "{\"url\":\"http://my.url.com\",\"cert\":\"mycert.pem\"}"
+            :content-type :json}))
+    
+    ;; content-type specified as json
+    (is (= (http/format-content {:url "http://my.url.com", :cert "mycert.pem", :content-type :json})
+           {:body "{\"url\":\"http://my.url.com\",\"cert\":\"mycert.pem\"}"
+            :content-type :json}))
+    
+    ;; content-type specified as multipart, format as passed.
+    (is (= (http/format-content {:url "http://my.url.com", :cert "mycert.pem", :content-type :multipart})
+           {:multipart
+            [{:name "url", :content "http://my.url.com"}
+             {:name "cert", :content "mycert.pem"}]}))))
+
 (def ok-resp
   {:cached nil
    :request-time 545


### PR DESCRIPTION
This pull request addresses a regression in functionality as reported in #139, that was introduced in #128 ([tagged in 2.8.0](https://github.com/wdhowe/telegrambot-lib/compare/2.7.0...2.8.0)).

Fiddle file for testing actual API calls updated

- Added tests to the core.clj fiddle file that check for functionality of using nil/long types during api calls and create a webhook with a custom pem cert file.

Code changes

- http: new function, format-content, which formats the given map as **multipart if specified, otherwise json is the default**.
- new http tests in order to validate the formatted return value of format-content.
- project, cheshire, jsonista version bumps.

All telegrambot_lib function calls format to json by default.

In order to specify multipart, simply include ":content-type :multipart" as part of your map when calling the function. Set webhook example:

```clojure
(set-webhook bot {:url "http://my.url.com"
                  :certificate (clojure.java.io/file "/path/to/cert.pem")
                  :content-type :multipart})
```

Closes #139 