### PR TITLE
issue-127: cljdoc not building since 2.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@
 pom.xml.asc
 profiles.clj
 /target
+/output-telegrambot-lib
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 
 test:
 	@echo "JSON with cheshire."
-	lein with-profiles +cheshire test :json
+	lein with-profile cheshire test :json
 	@echo "JSON with jsonista."
-	lein with-profiles +jsonista test :json
+	lein with-profile jsonista test :json
 	@echo "JSON with data.json."
-	lein with-profiles +data.json test :json
+	lein with-profile data.json test :json
 	@echo "All other tests."
-	lein with-profiles +cheshire test
+	lein test
 
 deploy: test
 	lein with-profile -dev deploy clojars

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,17 @@ package:
 	@echo "Create uberjar."
 	lein uberjar
 
+# Pre-req: clojure -Ttools install io.github.cljdoc/cljdoc-analyzer '{:git/tag "RELEASE"}' :as cljdoc
+# Analyze cljdoc api imports locally.
+cljdoc-analyze:
+	@PROJECT_VERSION=$$(awk '/defproject/ {print $$3}' project.clj | tr -d '"') ; \
+	clojure -Tcljdoc analyze \
+	:project '"telegrambot-lib/telegrambot-lib"' \
+	:version '"'$${PROJECT_VERSION}'"' \
+	:jarpath '"'./target/telegrambot-lib-$${PROJECT_VERSION}.jar'"' \
+	:pompath '"./pom.xml"' \
+	:extra-repo '["clojars https://repo.clojars.org/"]'
+
 clean:
 	@echo "Cleaning up built targets."
 	lein clean

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <url>https://github.com/wdhowe/telegrambot-lib</url>
     <connection>scm:git:git://github.com/wdhowe/telegrambot-lib.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/wdhowe/telegrambot-lib.git</developerConnection>
-    <tag>2a33b742f8dc22466e4840de8213179b3c6e5432</tag>
+    <tag>b73beb09dbdb0be3341b5e7b6c650c304054933f</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -97,10 +97,10 @@
       <version>0.4.6</version>
     </dependency>
     <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>data.json</artifactId>
-      <version>2.4.0</version>
-      <scope>provided</scope>
+      <groupId>cheshire</groupId>
+      <artifactId>cheshire</artifactId>
+      <version>5.12.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>clj-http-fake</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <url>https://github.com/wdhowe/telegrambot-lib</url>
     <connection>scm:git:git://github.com/wdhowe/telegrambot-lib.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/wdhowe/telegrambot-lib.git</developerConnection>
-    <tag>2906cbea99ebce1a7e8289439dc4d6c468721e69</tag>
+    <tag>2a33b742f8dc22466e4840de8213179b3c6e5432</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -95,6 +95,12 @@
       <groupId>potemkin</groupId>
       <artifactId>potemkin</artifactId>
       <version>0.4.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>data.json</artifactId>
+      <version>2.4.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>clj-http-fake</groupId>

--- a/project.clj
+++ b/project.clj
@@ -12,13 +12,14 @@
                  [org.clojure/clojure "1.11.1"]
                  [org.clojure/core.async "1.6.681"]
                  [org.clojure/tools.logging "1.2.4"]
-                 [potemkin "0.4.6"]
-                 [org.clojure/data.json "2.4.0" :scope "provided"]]
+                 [potemkin "0.4.6"]]
   
   ;;; Profiles
   ;; logback-classic must be 1.3.x due to jdk8 support.
   ;; See: https://github.com/wdhowe/telegrambot-lib/pull/120/commits/015d31621a3fd5a7f69dcf7c230d76d55f7a47c1
-  :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.3.5" :upgrade :logback]]
+  :profiles {;; REPL Jack-in with :dev,:local for development.
+             :dev {:dependencies [[ch.qos.logback/logback-classic "1.3.5" :upgrade :logback]
+                                  [cheshire "5.12.0"]]
                    :plugins [[lein-environ "1.2.0"]]
                    :resource-paths ["env/dev/resources"]}
              
@@ -26,11 +27,12 @@
              ;; Loads from profiles.clj (git ignored).
              :local {}
              
-             :test {:dependencies [[clj-http-fake/clj-http-fake "1.0.4"]]
+             :test {:dependencies [[cheshire "5.12.0"]
+                                   [clj-http-fake/clj-http-fake "1.0.4"]]
                     :plugins [[lein-environ "1.2.0"]]
                     :resource-paths ["env/test/resources"]}
              
-             ;; Select one of these json profiles during REPL jack-in.
+             ;; Profiles for testing json libraries.
              :cheshire {:dependencies [[cheshire "5.12.0"]]}
              
              :jsonista {:dependencies [[metosin/jsonista "0.3.8"]]}

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   
-  ;;; Dependencies, Plugins - scope provided for api analysis with cljdoc.
+  ;;; Dependencies, Plugins
   :dependencies [[clj-http "3.12.3"]
                  [environ "1.2.0"]
                  [org.clojure/clojure "1.11.1"]

--- a/project.clj
+++ b/project.clj
@@ -6,13 +6,14 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   
-  ;;; Dependencies, Plugins
+  ;;; Dependencies, Plugins - scope provided for api analysis with cljdoc.
   :dependencies [[clj-http "3.12.3"]
                  [environ "1.2.0"]
                  [org.clojure/clojure "1.11.1"]
                  [org.clojure/core.async "1.6.681"]
                  [org.clojure/tools.logging "1.2.4"]
-                 [potemkin "0.4.6"]]
+                 [potemkin "0.4.6"]
+                 [org.clojure/data.json "2.4.0" :scope "provided"]]
   
   ;;; Profiles
   ;; logback-classic must be 1.3.x due to jdk8 support.


### PR DESCRIPTION
## Describe your changes

Added a new dependency to project.clj, with a scope of provided. This allows for cljdoc-analyzer to successfully analyze the project api.

There is also a new Makefile target to run cljdoc-analyzer locally to ensure this would succeed.

## Issue ticket number and link

Closes #127 

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added tests or a new function call to a dev fiddle file.
  - [x] No new tests have been added.
  - [x] Existing tests and fiddle file executions pass.
  - [x] The new Makefile analysis target was successful locally.
  - [x] Verified that the inclusion of cheshire in the dev/test profiles did not propagate to the jar. (jar -tf telegrambot-lib-2.11.0-standalone.jar | grep cheshire)
