### PR TITLE
Added custom headers logic and tests

### DIFF
--- a/src/telegrambot_lib/config.clj
+++ b/src/telegrambot_lib/config.clj
@@ -9,4 +9,5 @@
   []
   {:bot-token (:bot-token environ/env)
    :async     false
-   :bot-api   (or (:bot-api environ/env) "https://api.telegram.org/bot")})
+   :bot-api   (or (:bot-api environ/env) "https://api.telegram.org/bot")
+   :headers   (constantly {})})

--- a/src/telegrambot_lib/core.clj
+++ b/src/telegrambot_lib/core.clj
@@ -26,9 +26,10 @@
    - bot-token ; The token id of your bot. (default: load from environment)
    - async ; Send API requests async or not. (default: false)
    - bot-api ; The Telegram Bot API URL. (default: official hosted API)
+   - headers ; Function of zero arguments returning map. (default: (constantly {}))
    
    Returns: A map data structure of a bot config."
-  {:changed "2.10.0"}
+  {:changed "2.13.0"}
   (fn
     ([] false)
     ([m] (map? m))))

--- a/test/telegrambot_lib/core_test.clj
+++ b/test/telegrambot_lib/core_test.clj
@@ -3,22 +3,25 @@
             [telegrambot-lib.core :as lib-core]))
 
 (deftest create-test-noparams
-  (testing "Test bot creation - no params specified.")
-  (let [mybot (lib-core/create)]
-    (is (= nil (:bot-token mybot)))
-    (is (= false (:async mybot)))
-    (is (= "https://api.telegram.org/bot" (:bot-api mybot)))))
+  (testing "Test bot creation - no params specified."
+    (let [mybot (lib-core/create)]
+      (is (= nil (:bot-token mybot)))
+      (is (= false (:async mybot)))
+      (is (= "https://api.telegram.org/bot" (:bot-api mybot)))
+      (is (= {} (-> mybot :headers (apply [])))))))
 
 (deftest create-test-token
   (testing "Test bot creation - token specified."
     (let [mybot (lib-core/create "123456")]
       (is (= "123456" (:bot-token mybot)))
       (is (= false (:async mybot)))
-      (is (= "https://api.telegram.org/bot" (:bot-api mybot))))))
+      (is (= "https://api.telegram.org/bot" (:bot-api mybot)))
+      (is (= {} (-> mybot :headers (apply [])))))))
 
 (deftest create-test-parammap
   (testing "Test bot creation - param map specified."
-    (let [mybot (lib-core/create {:bot-token "123456"})]
+    (let [mybot (lib-core/create {:bot-token "123456" :headers (constantly {"ABC" "123"})})]
       (is (= "123456" (:bot-token mybot)))
       (is (= false (:async mybot)))
-      (is (= "https://api.telegram.org/bot" (:bot-api mybot))))))
+      (is (= "https://api.telegram.org/bot" (:bot-api mybot)))
+      (is (= {"ABC" "123"} (-> mybot :headers (apply [])))))))


### PR DESCRIPTION
## Describe your changes

### What happened?

I am mocking Telegram API server for integration testing purposes. And I want seamless mulog traces from my Bot server to mock API server and back.

### Idea

Pass mulog's local context or whatever is needed with headers in HTTP requests.

### Solution

This pull request

## Checklist
- [ *] I have performed a self-review of my code.
- [ *] I have added tests or a new function call to a dev fiddle file.
